### PR TITLE
Feat/#1: seperate collision

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.3",
+    "@vitest/coverage-v8": "2.1.9",
+    "@vitest/ui": "^4.0.10",
     "eslint": "^9.36.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
@@ -62,6 +64,5 @@
     "typescript-eslint": "^8.44.0",
     "vite": "^7.1.7",
     "vitest": "^2.1.4"
-  },
-  "dependencies": {}
+  }
 }

--- a/playground/src/App.css
+++ b/playground/src/App.css
@@ -40,3 +40,39 @@
 .read-the-docs {
   color: #888;
 }
+
+/* playground app styles */
+.app {
+  padding: 24px;
+}
+
+.subtitle {
+  margin-bottom: 12px;
+}
+
+.board {
+  position: relative;
+  width: 600px;
+  height: 320px;
+  border: 1px dashed #999;
+  background: #fafafa;
+  user-select: none;
+}
+
+.draggable-block {
+  border-radius: 8px;
+  border: 1px solid #ccc;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+}
+
+.dragging-block {
+  border-radius: 8px;
+  border: 1px solid #bbb;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/playground/src/App.css
+++ b/playground/src/App.css
@@ -76,3 +76,16 @@
   align-items: center;
   justify-content: center;
 }
+
+.board-row {
+  display: flex;
+  gap: 24px;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.flex-column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -3,6 +3,7 @@ import './App.css';
 import { type BlockType } from '../../src';
 import RectangleBoard from './components/RectangleBoard';
 import CircleBoard from './components/CircleBoard';
+import OBBBoard from './components/OBBBoard';
 
 interface MyBlock extends BlockType {
   title: string;
@@ -40,6 +41,33 @@ function App() {
     },
   ]);
 
+  const [blocksOBB, setBlocksOBB] = useState<MyBlock[]>(() => [
+    {
+      id: 1,
+      position: { x: 40, y: 40 },
+      size: { width: 120, height: 60 },
+      angle: 0,
+      title: 'Block A',
+      color: '#fff',
+    },
+    {
+      id: 2,
+      position: { x: 220, y: 40 },
+      size: { width: 120, height: 60 },
+      angle: 0,
+      title: 'Block B',
+      color: '#fff',
+    },
+    {
+      id: 3,
+      position: { x: 40, y: 120 },
+      size: { width: 120, height: 60 },
+      angle: 0,
+      title: 'Block C',
+      color: '#fff',
+    },
+  ]);
+
   // kept for reference: updates happen inside board components
 
   const [blocksCircle, setBlocksCircle] = useState<MyBlock[]>(() => [
@@ -72,6 +100,14 @@ function App() {
         scrollOffset={scrollOffset}
         blocks={blocks}
         setBlocks={setBlocks}
+      />
+
+      <h3 className="subtitle">OBB collision</h3>
+      <OBBBoard<MyBlock>
+        containerRef={containerRef}
+        scrollOffset={scrollOffset}
+        blocks={blocksOBB}
+        setBlocks={setBlocksOBB}
       />
 
       <h3 className="subtitle">Circle collision</h3>

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -94,29 +94,36 @@ function App() {
       <h2>ddo-dnd playground</h2>
       <p className="subtitle">블록을 드래그하여 위치를 변경해 보세요.</p>
 
-      <h3 className="subtitle">Rectangle collision</h3>
-      <RectangleBoard<MyBlock>
-        containerRef={containerRef}
-        scrollOffset={scrollOffset}
-        blocks={blocks}
-        setBlocks={setBlocks}
-      />
+      <div className="board-row">
+        <div className="flex-column">
+          <h3 className="subtitle">Rectangle collision</h3>
+          <RectangleBoard<MyBlock>
+            containerRef={containerRef}
+            scrollOffset={scrollOffset}
+            blocks={blocks}
+            setBlocks={setBlocks}
+          />
+        </div>
 
-      <h3 className="subtitle">OBB collision</h3>
-      <OBBBoard<MyBlock>
-        containerRef={containerRef}
-        scrollOffset={scrollOffset}
-        blocks={blocksOBB}
-        setBlocks={setBlocksOBB}
-      />
-
-      <h3 className="subtitle">Circle collision</h3>
-      <CircleBoard<MyBlock>
-        containerRef={containerRefCircle}
-        scrollOffset={scrollOffset}
-        blocks={blocksCircle}
-        setBlocks={setBlocksCircle}
-      />
+        <div className="flex-column">
+          <h3 className="subtitle">OBB collision</h3>
+          <OBBBoard<MyBlock>
+            containerRef={containerRef}
+            scrollOffset={scrollOffset}
+            blocks={blocksOBB}
+            setBlocks={setBlocksOBB}
+          />
+        </div>
+      </div>
+      <div className="flex-column">
+        <h3 className="subtitle">Circle collision</h3>
+        <CircleBoard<MyBlock>
+          containerRef={containerRefCircle}
+          scrollOffset={scrollOffset}
+          blocks={blocksCircle}
+          setBlocks={setBlocksCircle}
+        />
+      </div>
     </div>
   );
 }

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -42,42 +42,47 @@ function App() {
       title: 'Block B',
       color: '#fff',
     },
+    {
+      id: 3,
+      position: { x: 40, y: 120 },
+      size: { width: 120, height: 60 },
+      title: 'Block C',
+      color: '#fff',
+    },
   ]);
 
-  const updateWorkBlockTimeOnServer = (updated: MyBlock) => {
+  const updateWorkBlockCallback = (updated: MyBlock) => {
     console.log('commit block (mock API):', updated);
     setBlocks(prevBlocks =>
       prevBlocks.map(block => (block.id === updated.id ? updated : block))
     );
   };
 
-  const { draggingBlock, dragPointerPosition, handleStartDrag, dragOffset } =
-    useDragBlock<MyBlock>({
-      containerRef,
-      scrollOffset,
-      workBlocks: blocks,
-      updateWorkBlockTimeOnServer,
-      updateWorkBlocks: setBlocks,
-    });
+  const {
+    draggingBlock,
+    dragPointerPosition,
+    handleStartDrag,
+    dragOffset,
+    collidedIds,
+  } = useDragBlock<MyBlock>({
+    containerRef,
+    scrollOffset,
+    workBlocks: blocks,
+    updateWorkBlockCallback,
+    updateWorkBlocks: setBlocks,
+    collisionOptions: {
+      enabled: true,
+      mode: 'rectangle',
+    },
+  });
 
   return (
-    <div style={{ padding: 24 }}>
+    <div className="app">
       <h2>ddo-dnd playground</h2>
-      <p style={{ marginBottom: 12 }}>
-        블록을 드래그하여 위치를 변경해 보세요.
-      </p>
+      <p className="subtitle">블록을 드래그하여 위치를 변경해 보세요.</p>
 
       <DragContainer containerRef={containerRef}>
-        <div
-          style={{
-            position: 'relative',
-            width: 600,
-            height: 320,
-            border: '1px dashed #999',
-            background: '#fafafa',
-            userSelect: 'none',
-          }}
-        >
+        <div className="board">
           {blocks.map(block => (
             <DraggableItem
               key={block.id}
@@ -88,17 +93,13 @@ function App() {
               }}
             >
               <div
+                className="draggable-block"
                 style={{
                   width: block.size.width,
                   height: block.size.height,
-                  borderRadius: 8,
-                  border: '1px solid #ccc',
-                  background: colorFromPosition(block.position),
-                  boxShadow: '0 1px 4px rgba(0,0,0,0.08)',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  fontSize: 14,
+                  background: collidedIds?.includes(block.id)
+                    ? 'red'
+                    : colorFromPosition(block.position),
                 }}
               >
                 {block.title} (X:{Math.round(block.position.x)} Y:
@@ -115,18 +116,13 @@ function App() {
               }}
             >
               <div
+                className="dragging-block"
                 style={{
                   width: draggingBlock.size.width,
                   height: draggingBlock.size.height,
-                  borderRadius: 8,
-                  border: '1px solid #bbb',
-                  background: colorFromPositionAlpha(
-                    draggingBlock.position,
-                    0.2
-                  ),
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
+                  background: collidedIds?.includes(draggingBlock.id)
+                    ? 'red'
+                    : colorFromPositionAlpha(draggingBlock.position, 0.2),
                 }}
               >
                 {draggingBlock.title} (X:{Math.round(draggingBlock.position.x)}{' '}

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -25,6 +25,7 @@ const colorFromPositionAlpha = (pos: { x: number; y: number }, alpha = 0.2) => {
 
 function App() {
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const containerRefCircle = useRef<HTMLDivElement | null>(null);
   const [scrollOffset] = useState(0);
 
   const [blocks, setBlocks] = useState<MyBlock[]>(() => [
@@ -76,11 +77,51 @@ function App() {
     },
   });
 
+  const [blocksCircle, setBlocksCircle] = useState<MyBlock[]>(() => [
+    {
+      id: 101,
+      position: { x: 60, y: 60 },
+      size: { width: 100, height: 100 },
+      title: 'Circle A',
+      color: '#fff',
+    },
+    {
+      id: 102,
+      position: { x: 240, y: 60 },
+      size: { width: 80, height: 80 },
+      title: 'Circle B',
+      color: '#fff',
+    },
+  ]);
+
+  const updateWorkBlockCallbackCircle = (updated: MyBlock) => {
+    setBlocksCircle(prev => prev.map(b => (b.id === updated.id ? updated : b)));
+  };
+
+  const {
+    draggingBlock: draggingBlock2,
+    dragPointerPosition: dragPointerPosition2,
+    handleStartDrag: handleStartDrag2,
+    dragOffset: dragOffset2,
+    collidedIds: collidedIds2,
+  } = useDragBlock<MyBlock>({
+    containerRef: containerRefCircle,
+    scrollOffset,
+    workBlocks: blocksCircle,
+    updateWorkBlockCallback: updateWorkBlockCallbackCircle,
+    updateWorkBlocks: setBlocksCircle,
+    collisionOptions: {
+      enabled: true,
+      mode: 'circle',
+    },
+  });
+
   return (
     <div className="app">
       <h2>ddo-dnd playground</h2>
       <p className="subtitle">블록을 드래그하여 위치를 변경해 보세요.</p>
 
+      <h3 className="subtitle">Rectangle collision</h3>
       <DragContainer containerRef={containerRef}>
         <div className="board">
           {blocks.map(block => (
@@ -128,6 +169,62 @@ function App() {
                 {draggingBlock.title} (X:{Math.round(draggingBlock.position.x)}{' '}
                 Y:
                 {Math.round(draggingBlock.position.y)})
+              </div>
+            </DraggingItem>
+          )}
+        </div>
+      </DragContainer>
+
+      <h3 className="subtitle">Circle collision</h3>
+      <DragContainer containerRef={containerRefCircle}>
+        <div className="board">
+          {blocksCircle.map(block => (
+            <DraggableItem
+              key={block.id}
+              position={block.position}
+              isDragging={draggingBlock2?.id === block.id}
+              handleStartDrag={(e: React.PointerEvent<HTMLDivElement>) => {
+                handleStartDrag2(e.nativeEvent as PointerEvent, block);
+              }}
+            >
+              <div
+                className="draggable-block"
+                style={{
+                  width: block.size.width,
+                  height: block.size.height,
+                  background: collidedIds2?.includes(block.id)
+                    ? 'red'
+                    : colorFromPosition(block.position),
+                  borderRadius: '50%',
+                }}
+              >
+                {block.title} (X:{Math.round(block.position.x)} Y:
+                {Math.round(block.position.y)})
+              </div>
+            </DraggableItem>
+          ))}
+
+          {dragPointerPosition2 && draggingBlock2 && (
+            <DraggingItem
+              position={{
+                x: dragPointerPosition2.x - dragOffset2.x,
+                y: dragPointerPosition2.y - dragOffset2.y,
+              }}
+            >
+              <div
+                className="dragging-block"
+                style={{
+                  width: draggingBlock2.size.width,
+                  height: draggingBlock2.size.height,
+                  background: collidedIds2?.includes(draggingBlock2.id)
+                    ? 'red'
+                    : colorFromPositionAlpha(draggingBlock2.position, 0.2),
+                  borderRadius: '50%',
+                }}
+              >
+                {draggingBlock2.title} (X:
+                {Math.round(draggingBlock2.position.x)} Y:
+                {Math.round(draggingBlock2.position.y)})
               </div>
             </DraggingItem>
           )}

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -20,7 +20,7 @@ function App() {
   const [blocks, setBlocks] = useState<MyBlock[]>(() => [
     {
       id: 1,
-      position: { x: 40, y: 40 },
+      position: { x: 60, y: 30 },
       size: { width: 120, height: 60 },
       title: 'Block A',
       color: '#fff',
@@ -43,26 +43,26 @@ function App() {
 
   const [blocksOBB, setBlocksOBB] = useState<MyBlock[]>(() => [
     {
-      id: 1,
-      position: { x: 40, y: 40 },
+      id: 4,
+      position: { x: 60, y: 40 },
       size: { width: 120, height: 60 },
       angle: 0,
       title: 'Block A',
       color: '#fff',
     },
     {
-      id: 2,
-      position: { x: 220, y: 40 },
+      id: 5,
+      position: { x: 220, y: 60 },
       size: { width: 120, height: 60 },
-      angle: 0,
+      angle: 15,
       title: 'Block B',
       color: '#fff',
     },
     {
-      id: 3,
-      position: { x: 40, y: 120 },
+      id: 6,
+      position: { x: 90, y: 140 },
       size: { width: 120, height: 60 },
-      angle: 0,
+      angle: -20,
       title: 'Block C',
       color: '#fff',
     },

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -1,27 +1,15 @@
 import { useRef, useState } from 'react';
 import './App.css';
-import {
-  DragContainer,
-  DraggableItem,
-  DraggingItem,
-  useDragBlock,
-  type BlockType,
-} from '../../src';
+import { type BlockType } from '../../src';
+import RectangleBoard from './components/RectangleBoard';
+import CircleBoard from './components/CircleBoard';
 
 interface MyBlock extends BlockType {
   title: string;
   color?: string;
 }
 
-const colorFromPosition = (pos: { x: number; y: number }) => {
-  const hue = Math.abs(pos.x * 37 + pos.y * 57) % 360;
-  return `hsl(${hue} 65% 60%)`;
-};
-
-const colorFromPositionAlpha = (pos: { x: number; y: number }, alpha = 0.2) => {
-  const hue = Math.abs(pos.x * 37 + pos.y * 57) % 360;
-  return `hsl(${hue} 65% 60% / ${alpha})`;
-};
+// color helpers moved to playground/src/utils/color.ts
 
 function App() {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -52,30 +40,7 @@ function App() {
     },
   ]);
 
-  const updateWorkBlockCallback = (updated: MyBlock) => {
-    console.log('commit block (mock API):', updated);
-    setBlocks(prevBlocks =>
-      prevBlocks.map(block => (block.id === updated.id ? updated : block))
-    );
-  };
-
-  const {
-    draggingBlock,
-    dragPointerPosition,
-    handleStartDrag,
-    dragOffset,
-    collidedIds,
-  } = useDragBlock<MyBlock>({
-    containerRef,
-    scrollOffset,
-    workBlocks: blocks,
-    updateWorkBlockCallback,
-    updateWorkBlocks: setBlocks,
-    collisionOptions: {
-      enabled: true,
-      mode: 'rectangle',
-    },
-  });
+  // kept for reference: updates happen inside board components
 
   const [blocksCircle, setBlocksCircle] = useState<MyBlock[]>(() => [
     {
@@ -94,27 +59,7 @@ function App() {
     },
   ]);
 
-  const updateWorkBlockCallbackCircle = (updated: MyBlock) => {
-    setBlocksCircle(prev => prev.map(b => (b.id === updated.id ? updated : b)));
-  };
-
-  const {
-    draggingBlock: draggingBlock2,
-    dragPointerPosition: dragPointerPosition2,
-    handleStartDrag: handleStartDrag2,
-    dragOffset: dragOffset2,
-    collidedIds: collidedIds2,
-  } = useDragBlock<MyBlock>({
-    containerRef: containerRefCircle,
-    scrollOffset,
-    workBlocks: blocksCircle,
-    updateWorkBlockCallback: updateWorkBlockCallbackCircle,
-    updateWorkBlocks: setBlocksCircle,
-    collisionOptions: {
-      enabled: true,
-      mode: 'circle',
-    },
-  });
+  // kept for reference: updates happen inside board components
 
   return (
     <div className="app">
@@ -122,114 +67,20 @@ function App() {
       <p className="subtitle">블록을 드래그하여 위치를 변경해 보세요.</p>
 
       <h3 className="subtitle">Rectangle collision</h3>
-      <DragContainer containerRef={containerRef}>
-        <div className="board">
-          {blocks.map(block => (
-            <DraggableItem
-              key={block.id}
-              position={block.position}
-              isDragging={draggingBlock?.id === block.id}
-              handleStartDrag={(e: React.PointerEvent<HTMLDivElement>) => {
-                handleStartDrag(e.nativeEvent as PointerEvent, block);
-              }}
-            >
-              <div
-                className="draggable-block"
-                style={{
-                  width: block.size.width,
-                  height: block.size.height,
-                  background: collidedIds?.includes(block.id)
-                    ? 'red'
-                    : colorFromPosition(block.position),
-                }}
-              >
-                {block.title} (X:{Math.round(block.position.x)} Y:
-                {Math.round(block.position.y)})
-              </div>
-            </DraggableItem>
-          ))}
-
-          {dragPointerPosition && draggingBlock && (
-            <DraggingItem
-              position={{
-                x: dragPointerPosition.x - dragOffset.x,
-                y: dragPointerPosition.y - dragOffset.y,
-              }}
-            >
-              <div
-                className="dragging-block"
-                style={{
-                  width: draggingBlock.size.width,
-                  height: draggingBlock.size.height,
-                  background: collidedIds?.includes(draggingBlock.id)
-                    ? 'red'
-                    : colorFromPositionAlpha(draggingBlock.position, 0.2),
-                }}
-              >
-                {draggingBlock.title} (X:{Math.round(draggingBlock.position.x)}{' '}
-                Y:
-                {Math.round(draggingBlock.position.y)})
-              </div>
-            </DraggingItem>
-          )}
-        </div>
-      </DragContainer>
+      <RectangleBoard<MyBlock>
+        containerRef={containerRef}
+        scrollOffset={scrollOffset}
+        blocks={blocks}
+        setBlocks={setBlocks}
+      />
 
       <h3 className="subtitle">Circle collision</h3>
-      <DragContainer containerRef={containerRefCircle}>
-        <div className="board">
-          {blocksCircle.map(block => (
-            <DraggableItem
-              key={block.id}
-              position={block.position}
-              isDragging={draggingBlock2?.id === block.id}
-              handleStartDrag={(e: React.PointerEvent<HTMLDivElement>) => {
-                handleStartDrag2(e.nativeEvent as PointerEvent, block);
-              }}
-            >
-              <div
-                className="draggable-block"
-                style={{
-                  width: block.size.width,
-                  height: block.size.height,
-                  background: collidedIds2?.includes(block.id)
-                    ? 'red'
-                    : colorFromPosition(block.position),
-                  borderRadius: '50%',
-                }}
-              >
-                {block.title} (X:{Math.round(block.position.x)} Y:
-                {Math.round(block.position.y)})
-              </div>
-            </DraggableItem>
-          ))}
-
-          {dragPointerPosition2 && draggingBlock2 && (
-            <DraggingItem
-              position={{
-                x: dragPointerPosition2.x - dragOffset2.x,
-                y: dragPointerPosition2.y - dragOffset2.y,
-              }}
-            >
-              <div
-                className="dragging-block"
-                style={{
-                  width: draggingBlock2.size.width,
-                  height: draggingBlock2.size.height,
-                  background: collidedIds2?.includes(draggingBlock2.id)
-                    ? 'red'
-                    : colorFromPositionAlpha(draggingBlock2.position, 0.2),
-                  borderRadius: '50%',
-                }}
-              >
-                {draggingBlock2.title} (X:
-                {Math.round(draggingBlock2.position.x)} Y:
-                {Math.round(draggingBlock2.position.y)})
-              </div>
-            </DraggingItem>
-          )}
-        </div>
-      </DragContainer>
+      <CircleBoard<MyBlock>
+        containerRef={containerRefCircle}
+        scrollOffset={scrollOffset}
+        blocks={blocksCircle}
+        setBlocks={setBlocksCircle}
+      />
     </div>
   );
 }

--- a/playground/src/components/CircleBoard.tsx
+++ b/playground/src/components/CircleBoard.tsx
@@ -7,6 +7,7 @@ import {
   type BlockType,
 } from '../../../src';
 import { colorFromPosition, colorFromPositionAlpha } from '../utils/color';
+import { useCollisionDetection } from '../../../src/hooks/useCollisionDetection';
 
 type WithTitle = BlockType & { title: string };
 
@@ -27,20 +28,17 @@ const CircleBoard = <T extends WithTitle>({
     setBlocks(prev => prev.map(b => (b.id === updated.id ? updated : b)));
   };
 
-  const {
-    draggingBlock,
-    dragPointerPosition,
-    handleStartDrag,
-    dragOffset,
-    collidedIds,
-  } = useDragBlock<T>({
-    containerRef,
-    scrollOffset,
-    workBlocks: blocks,
-    updateWorkBlockCallback,
-    updateWorkBlocks: setBlocks,
-    collisionOptions: { enabled: true, mode: 'circle' },
-  });
+  const { collidedIds } = useCollisionDetection<T>();
+
+  const { draggingBlock, dragPointerPosition, handleStartDrag, dragOffset } =
+    useDragBlock<T>({
+      containerRef,
+      scrollOffset,
+      workBlocks: blocks,
+      updateWorkBlockCallback,
+      updateWorkBlocks: setBlocks,
+      collisionOptions: { enabled: true, mode: 'circle' },
+    });
 
   return (
     <DragContainer containerRef={containerRef}>

--- a/playground/src/components/CircleBoard.tsx
+++ b/playground/src/components/CircleBoard.tsx
@@ -1,0 +1,102 @@
+import { type RefObject } from 'react';
+import {
+  DragContainer,
+  DraggableItem,
+  DraggingItem,
+  useDragBlock,
+  type BlockType,
+} from '../../../src';
+import { colorFromPosition, colorFromPositionAlpha } from '../utils/color';
+
+type WithTitle = BlockType & { title: string };
+
+interface CircleBoardProps<T extends WithTitle> {
+  containerRef: RefObject<HTMLDivElement | null>;
+  scrollOffset: number;
+  blocks: T[];
+  setBlocks: React.Dispatch<React.SetStateAction<T[]>>;
+}
+
+const CircleBoard = <T extends WithTitle>({
+  containerRef,
+  scrollOffset,
+  blocks,
+  setBlocks,
+}: CircleBoardProps<T>) => {
+  const updateWorkBlockCallback = (updated: T) => {
+    setBlocks(prev => prev.map(b => (b.id === updated.id ? updated : b)));
+  };
+
+  const {
+    draggingBlock,
+    dragPointerPosition,
+    handleStartDrag,
+    dragOffset,
+    collidedIds,
+  } = useDragBlock<T>({
+    containerRef,
+    scrollOffset,
+    workBlocks: blocks,
+    updateWorkBlockCallback,
+    updateWorkBlocks: setBlocks,
+    collisionOptions: { enabled: true, mode: 'circle' },
+  });
+
+  return (
+    <DragContainer containerRef={containerRef}>
+      <div className="board">
+        {blocks.map(block => (
+          <DraggableItem
+            key={block.id}
+            position={block.position}
+            isDragging={draggingBlock?.id === block.id}
+            handleStartDrag={(e: React.PointerEvent<HTMLDivElement>) => {
+              handleStartDrag(e.nativeEvent as PointerEvent, block);
+            }}
+          >
+            <div
+              className="draggable-block"
+              style={{
+                width: block.size.width,
+                height: block.size.height,
+                background: collidedIds?.includes(block.id)
+                  ? 'red'
+                  : colorFromPosition(block.position),
+                borderRadius: '50%',
+              }}
+            >
+              {block.title} (X:{Math.round(block.position.x)} Y:
+              {Math.round(block.position.y)})
+            </div>
+          </DraggableItem>
+        ))}
+
+        {dragPointerPosition && draggingBlock && (
+          <DraggingItem
+            position={{
+              x: dragPointerPosition.x - dragOffset.x,
+              y: dragPointerPosition.y - dragOffset.y,
+            }}
+          >
+            <div
+              className="dragging-block"
+              style={{
+                width: draggingBlock.size.width,
+                height: draggingBlock.size.height,
+                background: collidedIds?.includes(draggingBlock.id)
+                  ? 'red'
+                  : colorFromPositionAlpha(draggingBlock.position, 0.2),
+                borderRadius: '50%',
+              }}
+            >
+              {draggingBlock.title} (X:{Math.round(draggingBlock.position.x)} Y:
+              {Math.round(draggingBlock.position.y)})
+            </div>
+          </DraggingItem>
+        )}
+      </div>
+    </DragContainer>
+  );
+};
+
+export default CircleBoard;

--- a/playground/src/components/OBBBoard.tsx
+++ b/playground/src/components/OBBBoard.tsx
@@ -1,0 +1,197 @@
+import { type RefObject, useEffect, useState } from 'react';
+import {
+  DragContainer,
+  DraggableItem,
+  DraggingItem,
+  useDragBlock,
+  type BlockType,
+} from '../../../src';
+import { colorFromPosition, colorFromPositionAlpha } from '../utils/color';
+
+type WithAngle = BlockType & { title: string; angle?: number };
+
+interface OBBBoardProps<T extends WithAngle> {
+  containerRef: RefObject<HTMLDivElement | null>;
+  scrollOffset: number;
+  blocks: T[];
+  setBlocks: React.Dispatch<React.SetStateAction<T[]>>;
+}
+
+const OBBBoard = <T extends WithAngle>({
+  containerRef,
+  scrollOffset,
+  blocks,
+  setBlocks,
+}: OBBBoardProps<T>) => {
+  const [rotating, setRotating] = useState<{
+    id: number;
+    angleStartDeg: number;
+    startPointerAngleRad: number;
+  } | null>(null);
+
+  const updateWorkBlockCallback = (updated: T) => {
+    setBlocks(prev => prev.map(b => (b.id === updated.id ? updated : b)));
+  };
+
+  const {
+    draggingBlock,
+    dragPointerPosition,
+    handleStartDrag,
+    dragOffset,
+    collidedIds,
+  } = useDragBlock<T>({
+    containerRef,
+    scrollOffset,
+    workBlocks: blocks,
+    updateWorkBlockCallback,
+    updateWorkBlocks: setBlocks,
+    collisionOptions: { enabled: true, mode: 'obb' },
+  });
+
+  // 회전 핸들 pointermove/up 전역 처리
+  useEffect(() => {
+    if (!rotating) return;
+    const handleMove = (e: PointerEvent) => {
+      const targetBlock = blocks.find(b => Number(b.id) === rotating.id);
+      if (!targetBlock) return;
+      const rect = containerRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const centerX =
+        rect.left + targetBlock.position.x + targetBlock.size.width / 2;
+      const centerY =
+        rect.top + targetBlock.position.y + targetBlock.size.height / 2;
+      const currentAngleRad = Math.atan2(
+        e.clientY - centerY,
+        e.clientX - centerX
+      );
+      const deltaRad = currentAngleRad - rotating.startPointerAngleRad;
+      const deltaDeg = (deltaRad * 180) / Math.PI;
+      const nextDeg = rotating.angleStartDeg + deltaDeg;
+      setBlocks(prev =>
+        prev.map(b =>
+          Number(b.id) === rotating.id ? { ...b, angle: nextDeg } : b
+        )
+      );
+    };
+    const handleUp = () => {
+      setRotating(null);
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', handleUp);
+    };
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', handleUp);
+    return () => {
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', handleUp);
+    };
+  }, [rotating, blocks, containerRef, setBlocks]);
+
+  const startRotate = (e: React.PointerEvent, block: T) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const centerX = rect.left + block.position.x + block.size.width / 2;
+    const centerY = rect.top + block.position.y + block.size.height / 2;
+    const startPointerAngleRad = Math.atan2(
+      e.clientY - centerY,
+      e.clientX - centerX
+    );
+    const angleStartDeg = block.angle ?? 0;
+    setRotating({
+      id: Number(block.id),
+      angleStartDeg,
+      startPointerAngleRad,
+    });
+  };
+
+  const cornerHandleStyle: React.CSSProperties = {
+    position: 'absolute',
+    width: 10,
+    height: 10,
+    borderRadius: '50%',
+    background: '#fff',
+    border: '1px solid #000',
+    cursor: rotating ? 'grabbing' : 'grab',
+  };
+
+  return (
+    <DragContainer containerRef={containerRef}>
+      <div className="board">
+        {blocks.map(block => (
+          <DraggableItem
+            key={block.id}
+            position={block.position}
+            isDragging={draggingBlock?.id === block.id}
+            handleStartDrag={(e: React.PointerEvent<HTMLDivElement>) => {
+              handleStartDrag(e.nativeEvent as PointerEvent, block);
+            }}
+          >
+            <div
+              className="draggable-block"
+              style={{
+                position: 'relative',
+                width: block.size.width,
+                height: block.size.height,
+                transform: `rotate(${block.angle ?? 0}deg)`,
+                transformOrigin: 'center',
+                background: collidedIds?.includes(block.id)
+                  ? 'red'
+                  : colorFromPosition(block.position),
+              }}
+            >
+              {block.title} (X:{Math.round(block.position.x)} Y:
+              {Math.round(block.position.y)})
+              <br />
+              Angle: {Math.round(block.angle ?? 0)}deg
+              <div
+                style={{ ...cornerHandleStyle, left: -5, top: -5 }}
+                onPointerDown={e => startRotate(e, block)}
+              />
+              <div
+                style={{ ...cornerHandleStyle, right: -5, top: -5 }}
+                onPointerDown={e => startRotate(e, block)}
+              />
+              <div
+                style={{ ...cornerHandleStyle, left: -5, bottom: -5 }}
+                onPointerDown={e => startRotate(e, block)}
+              />
+              <div
+                style={{ ...cornerHandleStyle, right: -5, bottom: -5 }}
+                onPointerDown={e => startRotate(e, block)}
+              />
+            </div>
+          </DraggableItem>
+        ))}
+
+        {dragPointerPosition && draggingBlock && (
+          <DraggingItem
+            position={{
+              x: dragPointerPosition.x - dragOffset.x,
+              y: dragPointerPosition.y - dragOffset.y,
+            }}
+          >
+            <div
+              className="dragging-block"
+              style={{
+                width: draggingBlock.size.width,
+                height: draggingBlock.size.height,
+                transform: `rotate(${draggingBlock.angle ?? 0}deg)`,
+                transformOrigin: 'center',
+                background: collidedIds?.includes(draggingBlock.id)
+                  ? 'red'
+                  : colorFromPositionAlpha(draggingBlock.position, 0.2),
+              }}
+            >
+              {draggingBlock.title} (X:{Math.round(draggingBlock.position.x)} Y:
+              {Math.round(draggingBlock.position.y)})
+              <br /> Angle:{Math.round(draggingBlock.angle ?? 0)}deg
+            </div>
+          </DraggingItem>
+        )}
+      </div>
+    </DragContainer>
+  );
+};
+
+export default OBBBoard;

--- a/playground/src/components/OBBBoard.tsx
+++ b/playground/src/components/OBBBoard.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../src';
 import { useRotateBlock } from '../../../src';
 import { colorFromPosition, colorFromPositionAlpha } from '../utils/color';
+import { useCollisionDetection } from '../../../src/hooks/useCollisionDetection';
 
 type WithAngle = BlockType & { title: string; angle?: number };
 
@@ -27,21 +28,17 @@ const OBBBoard = <T extends WithAngle>({
   const updateWorkBlockCallback = (updated: T) => {
     setBlocks(prev => prev.map(b => (b.id === updated.id ? updated : b)));
   };
+  const { collidedIds } = useCollisionDetection<T>();
 
-  const {
-    draggingBlock,
-    dragPointerPosition,
-    handleStartDrag,
-    dragOffset,
-    collidedIds,
-  } = useDragBlock<T>({
-    containerRef,
-    scrollOffset,
-    workBlocks: blocks,
-    updateWorkBlockCallback,
-    updateWorkBlocks: setBlocks,
-    collisionOptions: { enabled: true, mode: 'obb' },
-  });
+  const { draggingBlock, dragPointerPosition, handleStartDrag, dragOffset } =
+    useDragBlock<T>({
+      containerRef,
+      scrollOffset,
+      workBlocks: blocks,
+      updateWorkBlockCallback,
+      updateWorkBlocks: setBlocks,
+      collisionOptions: { enabled: true, mode: 'obb' },
+    });
 
   const {
     rotatingBlock,

--- a/playground/src/components/RectangleBoard.tsx
+++ b/playground/src/components/RectangleBoard.tsx
@@ -7,6 +7,7 @@ import {
   type BlockType,
 } from '../../../src';
 import { colorFromPosition, colorFromPositionAlpha } from '../utils/color';
+import { useCollisionDetection } from '../../../src/hooks/useCollisionDetection';
 
 type WithTitle = BlockType & { title: string };
 
@@ -27,20 +28,17 @@ const RectangleBoard = <T extends WithTitle>({
     setBlocks(prev => prev.map(b => (b.id === updated.id ? updated : b)));
   };
 
-  const {
-    draggingBlock,
-    dragPointerPosition,
-    handleStartDrag,
-    dragOffset,
-    collidedIds,
-  } = useDragBlock<T>({
-    containerRef,
-    scrollOffset,
-    workBlocks: blocks,
-    updateWorkBlockCallback,
-    updateWorkBlocks: setBlocks,
-    collisionOptions: { enabled: true, mode: 'rectangle' },
-  });
+  const { collidedIds } = useCollisionDetection<T>();
+
+  const { draggingBlock, dragPointerPosition, handleStartDrag, dragOffset } =
+    useDragBlock<T>({
+      containerRef,
+      scrollOffset,
+      workBlocks: blocks,
+      updateWorkBlockCallback,
+      updateWorkBlocks: setBlocks,
+      collisionOptions: { enabled: true, mode: 'rectangle' },
+    });
 
   return (
     <DragContainer containerRef={containerRef}>

--- a/playground/src/components/RectangleBoard.tsx
+++ b/playground/src/components/RectangleBoard.tsx
@@ -1,0 +1,100 @@
+import { type RefObject } from 'react';
+import {
+  DragContainer,
+  DraggableItem,
+  DraggingItem,
+  useDragBlock,
+  type BlockType,
+} from '../../../src';
+import { colorFromPosition, colorFromPositionAlpha } from '../utils/color';
+
+type WithTitle = BlockType & { title: string };
+
+interface RectangleBoardProps<T extends WithTitle> {
+  containerRef: RefObject<HTMLDivElement | null>;
+  scrollOffset: number;
+  blocks: T[];
+  setBlocks: React.Dispatch<React.SetStateAction<T[]>>;
+}
+
+const RectangleBoard = <T extends WithTitle>({
+  containerRef,
+  scrollOffset,
+  blocks,
+  setBlocks,
+}: RectangleBoardProps<T>) => {
+  const updateWorkBlockCallback = (updated: T) => {
+    setBlocks(prev => prev.map(b => (b.id === updated.id ? updated : b)));
+  };
+
+  const {
+    draggingBlock,
+    dragPointerPosition,
+    handleStartDrag,
+    dragOffset,
+    collidedIds,
+  } = useDragBlock<T>({
+    containerRef,
+    scrollOffset,
+    workBlocks: blocks,
+    updateWorkBlockCallback,
+    updateWorkBlocks: setBlocks,
+    collisionOptions: { enabled: true, mode: 'rectangle' },
+  });
+
+  return (
+    <DragContainer containerRef={containerRef}>
+      <div className="board">
+        {blocks.map(block => (
+          <DraggableItem
+            key={block.id}
+            position={block.position}
+            isDragging={draggingBlock?.id === block.id}
+            handleStartDrag={(e: React.PointerEvent<HTMLDivElement>) => {
+              handleStartDrag(e.nativeEvent as PointerEvent, block);
+            }}
+          >
+            <div
+              className="draggable-block"
+              style={{
+                width: block.size.width,
+                height: block.size.height,
+                background: collidedIds?.includes(block.id)
+                  ? 'red'
+                  : colorFromPosition(block.position),
+              }}
+            >
+              {block.title} (X:{Math.round(block.position.x)} Y:
+              {Math.round(block.position.y)})
+            </div>
+          </DraggableItem>
+        ))}
+
+        {dragPointerPosition && draggingBlock && (
+          <DraggingItem
+            position={{
+              x: dragPointerPosition.x - dragOffset.x,
+              y: dragPointerPosition.y - dragOffset.y,
+            }}
+          >
+            <div
+              className="dragging-block"
+              style={{
+                width: draggingBlock.size.width,
+                height: draggingBlock.size.height,
+                background: collidedIds?.includes(draggingBlock.id)
+                  ? 'red'
+                  : colorFromPositionAlpha(draggingBlock.position, 0.2),
+              }}
+            >
+              {draggingBlock.title} (X:{Math.round(draggingBlock.position.x)} Y:
+              {Math.round(draggingBlock.position.y)})
+            </div>
+          </DraggingItem>
+        )}
+      </div>
+    </DragContainer>
+  );
+};
+
+export default RectangleBoard;

--- a/playground/src/utils/color.ts
+++ b/playground/src/utils/color.ts
@@ -1,0 +1,12 @@
+export const colorFromPosition = (pos: { x: number; y: number }) => {
+  const hue = Math.abs(pos.x * 37 + pos.y * 57) % 360;
+  return `hsl(${hue} 65% 60%)`;
+};
+
+export const colorFromPositionAlpha = (
+  pos: { x: number; y: number },
+  alpha = 0.2
+) => {
+  const hue = Math.abs(pos.x * 37 + pos.y * 57) % 360;
+  return `hsl(${hue} 65% 60% / ${alpha})`;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@jest/globals':
-        specifier: ^30.2.0
-        version: 30.2.0
       react:
         specifier: '>=18'
         version: 19.1.1
@@ -39,6 +36,12 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.0.3
         version: 5.0.4(vite@7.1.7(@types/node@24.6.2))
+      '@vitest/coverage-v8':
+        specifier: 2.1.9
+        version: 2.1.9(vitest@2.1.9)
+      '@vitest/ui':
+        specifier: ^4.0.10
+        version: 4.0.10(vitest@2.1.9)
       eslint:
         specifier: ^9.36.0
         version: 9.36.0
@@ -65,12 +68,16 @@ importers:
         version: 7.1.7(@types/node@24.6.2)
       vitest:
         specifier: ^2.1.4
-        version: 2.1.9(@types/node@24.6.2)(jsdom@25.0.1)
+        version: 2.1.9(@types/node@24.6.2)(@vitest/ui@4.0.10)(jsdom@25.0.1)
 
 packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -134,97 +141,6 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/plugin-syntax-async-generators@7.8.4':
-    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-bigint@7.8.3':
-    resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-class-properties@7.12.13':
-    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-class-static-block@7.14.5':
-    resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-import-attributes@7.27.1':
-    resolution: {integrity: sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-import-meta@7.10.4':
-    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-json-strings@7.8.3':
-    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-jsx@7.27.1':
-    resolution: {integrity: sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4':
-    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3':
-    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-numeric-separator@7.10.4':
-    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-object-rest-spread@7.8.3':
-    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3':
-    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-optional-chaining@7.8.3':
-    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-private-property-in-object@7.14.5':
-    resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-top-level-await@7.14.5':
-    resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-typescript@7.27.1':
-    resolution: {integrity: sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-react-jsx-self@7.27.1':
     resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
     engines: {node: '>=6.9.0'}
@@ -252,6 +168,9 @@ packages:
   '@babel/types@7.28.4':
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -629,61 +548,13 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@istanbuljs/load-nyc-config@1.1.0':
-    resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
-    engines: {node: '>=8'}
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
 
   '@istanbuljs/schema@0.1.3':
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
-
-  '@jest/diff-sequences@30.0.1':
-    resolution: {integrity: sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/environment@30.2.0':
-    resolution: {integrity: sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/expect-utils@30.2.0':
-    resolution: {integrity: sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/expect@30.2.0':
-    resolution: {integrity: sha512-V9yxQK5erfzx99Sf+7LbhBwNWEZ9eZay8qQ9+JSC0TrMR1pMDHLMY+BnVPacWU6Jamrh252/IKo4F1Xn/zfiqA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/fake-timers@30.2.0':
-    resolution: {integrity: sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/get-type@30.1.0':
-    resolution: {integrity: sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/globals@30.2.0':
-    resolution: {integrity: sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/pattern@30.0.1':
-    resolution: {integrity: sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/schemas@30.0.5':
-    resolution: {integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/snapshot-utils@30.2.0':
-    resolution: {integrity: sha512-0aVxM3RH6DaiLcjj/b0KrIBZhSX1373Xci4l3cW5xiUWPctZ59zQ7jj4rqcJQ/Z8JuN/4wX3FpJSa3RssVvCug==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/transform@30.2.0':
-    resolution: {integrity: sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/types@30.2.0':
-    resolution: {integrity: sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -713,9 +584,12 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@pkgr/core@0.2.9':
-    resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
-    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
   '@rolldown/pluginutils@1.0.0-beta.38':
     resolution: {integrity: sha512-N/ICGKleNhA5nc9XXQG/kkKHJ7S55u0x0XUJbbkmdCnFuoRkM1Il12q9q0eX19+M7KKUEPw/daUPIRnxhcxAIw==}
@@ -830,15 +704,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@sinclair/typebox@0.34.41':
-    resolution: {integrity: sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==}
-
-  '@sinonjs/commons@3.0.1':
-    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
-
-  '@sinonjs/fake-timers@13.0.5':
-    resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
-
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -886,15 +751,6 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/istanbul-lib-coverage@2.0.6':
-    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
-
-  '@types/istanbul-lib-report@3.0.3':
-    resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
-
-  '@types/istanbul-reports@3.0.4':
-    resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
-
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -908,15 +764,6 @@ packages:
 
   '@types/react@19.1.16':
     resolution: {integrity: sha512-WBM/nDbEZmDUORKnh5i1bTnAz6vTohUf9b8esSMu+b24+srbaxa04UbJgWx78CVfNXA20sNu0odEIluZDFdCog==}
-
-  '@types/stack-utils@2.0.3':
-    resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
-
-  '@types/yargs-parser@21.0.3':
-    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
-
-  '@types/yargs@17.0.33':
-    resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
 
   '@typescript-eslint/eslint-plugin@8.45.0':
     resolution: {integrity: sha512-HC3y9CVuevvWCl/oyZuI47dOeDF9ztdMEfMH8/DW/Mhwa9cCLnK1oD7JoTVGW/u7kFzNZUKUoyJEqkaJh5y3Wg==}
@@ -977,14 +824,20 @@ packages:
     resolution: {integrity: sha512-qsaFBA3e09MIDAGFUrTk+dzqtfv1XPVz8t8d1f0ybTzrCY7BKiMC5cjrl1O/P7UmHsNyW90EYSkU/ZWpmXelag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@ungap/structured-clone@1.3.0':
-    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
-
   '@vitejs/plugin-react@5.0.4':
     resolution: {integrity: sha512-La0KD0vGkVkSk6K+piWDKRUyg8Rl5iAIKRMH0vMJI0Eg47bq1eOxmoObAaQG37WMW9MSyk7Cs8EIWwJC1PtzKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitest/coverage-v8@2.1.9':
+    resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
+    peerDependencies:
+      '@vitest/browser': 2.1.9
+      vitest: 2.1.9
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -1003,6 +856,9 @@ packages:
   '@vitest/pretty-format@2.1.9':
     resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
 
+  '@vitest/pretty-format@4.0.10':
+    resolution: {integrity: sha512-99EQbpa/zuDnvVjthwz5bH9o8iPefoQZ63WV8+bsRJZNw3qQSvSltfut8yu1Jc9mqOYi7pEbsKxYTi/rjaq6PA==}
+
   '@vitest/runner@2.1.9':
     resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
@@ -1012,8 +868,16 @@ packages:
   '@vitest/spy@2.1.9':
     resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
 
+  '@vitest/ui@4.0.10':
+    resolution: {integrity: sha512-oWtNM89Np+YsQO3ttT5i1Aer/0xbzQzp66NzuJn/U16bB7MnvSzdLKXgk1kkMLYyKSSzA2ajzqMkYheaE9opuQ==}
+    peerDependencies:
+      vitest: 4.0.10
+
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@vitest/utils@4.0.10':
+    resolution: {integrity: sha512-kOuqWnEwZNtQxMKg3WmPK1vmhZu9WcoX69iwWjVz+jvKTsF1emzsv3eoPcDr6ykA3qP2bsCQE7CwqfNtAVzsmg==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1036,6 +900,10 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -1044,12 +912,9 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
-  anymatch@3.1.3:
-    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
-    engines: {node: '>= 8'}
-
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1067,15 +932,6 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
-  babel-plugin-istanbul@7.0.1:
-    resolution: {integrity: sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==}
-    engines: {node: '>=12'}
-
-  babel-preset-current-node-syntax@1.2.0:
-    resolution: {integrity: sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0 || ^8.0.0-0
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1099,9 +955,6 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  bser@2.1.1:
-    resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
-
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -1112,10 +965,6 @@ packages:
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
-
-  camelcase@5.3.1:
-    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
 
   caniuse-lite@1.0.30001746:
@@ -1132,10 +981,6 @@ packages:
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
-
-  ci-info@4.3.0:
-    resolution: {integrity: sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==}
-    engines: {node: '>=8'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1209,8 +1054,17 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   electron-to-chromium@1.5.227:
     resolution: {integrity: sha512-ITxuoPfJu3lsNWUi2lBM2PaBPYgH3uqmxut5vmBxgYvyI4AlJ6P3Cai1O76mOrkJCBzq0IxWg/NtqOrpu/0gKA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1248,10 +1102,6 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
-
-  escape-string-regexp@2.0.0:
-    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
-    engines: {node: '>=8'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1294,11 +1144,6 @@ packages:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
-
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
@@ -1322,10 +1167,6 @@ packages:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
 
-  expect@30.2.0:
-    resolution: {integrity: sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1342,9 +1183,6 @@ packages:
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
-  fb-watchman@2.0.2:
-    resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
-
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1354,16 +1192,15 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
-    engines: {node: '>=8'}
-
-  find-up@4.1.0:
-    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
   find-up@5.0.0:
@@ -1377,12 +1214,13 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
-
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1400,10 +1238,6 @@ packages:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
 
-  get-package-type@0.1.0:
-    resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
-    engines: {node: '>=8.0.0'}
-
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
@@ -1416,9 +1250,9 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -1431,9 +1265,6 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
-
-  graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
@@ -1457,6 +1288,9 @@ packages:
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -1490,16 +1324,13 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
-
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -1519,52 +1350,23 @@ packages:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
 
-  istanbul-lib-instrument@6.0.3:
-    resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
 
-  jest-diff@30.2.0:
-    resolution: {integrity: sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
 
-  jest-haste-map@30.2.0:
-    resolution: {integrity: sha512-sQA/jCb9kNt+neM0anSj6eZhLZUIhQgwDt7cPGjumgLM4rXsfb9kpnlacmvZz3Q5tb80nS+oG/if+NBKrHC+Xw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
 
-  jest-matcher-utils@30.2.0:
-    resolution: {integrity: sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-message-util@30.2.0:
-    resolution: {integrity: sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-mock@30.2.0:
-    resolution: {integrity: sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-regex-util@30.0.1:
-    resolution: {integrity: sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-snapshot@30.2.0:
-    resolution: {integrity: sha512-5WEtTy2jXPFypadKNpbNkZ72puZCa6UjSr/7djeecHWOu7iYhSXSnHScT8wBz3Rn8Ena5d5RYRcsyKIeqG1IyA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-util@30.2.0:
-    resolution: {integrity: sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-worker@30.2.0:
-    resolution: {integrity: sha512-0Q4Uk8WF7BUwqXHuAjc23vmopWJw5WH7w2tqBoUOZpOjW/ZnR44GXXd1r82RvnmI2GZge3ivrYXk/BE2+VtW2g==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@3.14.1:
-    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
-    hasBin: true
 
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -1605,10 +1407,6 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  locate-path@5.0.0:
-    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
-    engines: {node: '>=8'}
-
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -1632,15 +1430,16 @@ packages:
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
-  makeerror@1.0.12:
-    resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
-
-  merge-stream@2.0.0:
-    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1669,6 +1468,14 @@ packages:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1680,45 +1487,26 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  node-int64@0.4.0:
-    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
-
   node-releases@2.0.21:
     resolution: {integrity: sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==}
 
-  normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
-
   nwsapi@2.2.22:
     resolution: {integrity: sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
-  p-limit@2.3.0:
-    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
-    engines: {node: '>=6'}
-
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
-
-  p-locate@4.1.0:
-    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
-    engines: {node: '>=8'}
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
-  p-try@2.2.0:
-    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
-    engines: {node: '>=6'}
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -1731,16 +1519,19 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
-  path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
-
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
@@ -1757,10 +1548,6 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
-  pirates@4.0.7:
-    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
-    engines: {node: '>= 6'}
-
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1772,10 +1559,6 @@ packages:
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-
-  pretty-format@30.2.0:
-    resolution: {integrity: sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -1792,9 +1575,6 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  react-is@18.3.1:
-    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
-
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
@@ -1810,10 +1590,6 @@ packages:
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
-
-  resolve-from@5.0.0:
-    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
-    engines: {node: '>=8'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -1867,26 +1643,35 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  slash@3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
-    engines: {node: '>=8'}
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
-
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
-  stack-utils@2.0.6:
-    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
-    engines: {node: '>=10'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.1.2:
+    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
+    engines: {node: '>=12'}
 
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
@@ -1900,20 +1685,12 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
-  supports-color@8.1.1:
-    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
-    engines: {node: '>=10'}
-
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
-  synckit@0.11.11:
-    resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-
-  test-exclude@6.0.0:
-    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
-    engines: {node: '>=8'}
+  test-exclude@7.0.1:
+    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1933,6 +1710,10 @@ packages:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
     engines: {node: '>=14.0.0'}
 
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
+
   tinyspy@3.0.2:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
@@ -1944,12 +1725,13 @@ packages:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
-  tmpl@1.0.5:
-    resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
-
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
 
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
@@ -1968,10 +1750,6 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
-
-  type-detect@4.0.8:
-    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
-    engines: {node: '>=4'}
 
   typescript-eslint@8.45.0:
     resolution: {integrity: sha512-qzDmZw/Z5beNLUrXfd0HIW6MzIaAV5WNDxmMs9/3ojGOpYavofgNAAD/nC6tGV2PczIi0iw8vot2eAe/sBn7zg==}
@@ -2102,9 +1880,6 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
-  walker@1.0.8:
-    resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
-
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -2135,12 +1910,13 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
 
-  write-file-atomic@5.0.1:
-    resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
@@ -2171,6 +1947,11 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -2259,91 +2040,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.4
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.4)':
     dependencies:
       '@babel/core': 7.28.4
@@ -2378,6 +2074,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+
+  '@bcoe/v8-coverage@0.2.3': {}
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -2601,101 +2299,16 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@istanbuljs/load-nyc-config@1.1.0':
+  '@isaacs/cliui@8.0.2':
     dependencies:
-      camelcase: 5.3.1
-      find-up: 4.1.0
-      get-package-type: 0.1.0
-      js-yaml: 3.14.1
-      resolve-from: 5.0.0
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.2
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@istanbuljs/schema@0.1.3': {}
-
-  '@jest/diff-sequences@30.0.1': {}
-
-  '@jest/environment@30.2.0':
-    dependencies:
-      '@jest/fake-timers': 30.2.0
-      '@jest/types': 30.2.0
-      '@types/node': 24.6.2
-      jest-mock: 30.2.0
-
-  '@jest/expect-utils@30.2.0':
-    dependencies:
-      '@jest/get-type': 30.1.0
-
-  '@jest/expect@30.2.0':
-    dependencies:
-      expect: 30.2.0
-      jest-snapshot: 30.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@jest/fake-timers@30.2.0':
-    dependencies:
-      '@jest/types': 30.2.0
-      '@sinonjs/fake-timers': 13.0.5
-      '@types/node': 24.6.2
-      jest-message-util: 30.2.0
-      jest-mock: 30.2.0
-      jest-util: 30.2.0
-
-  '@jest/get-type@30.1.0': {}
-
-  '@jest/globals@30.2.0':
-    dependencies:
-      '@jest/environment': 30.2.0
-      '@jest/expect': 30.2.0
-      '@jest/types': 30.2.0
-      jest-mock: 30.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@jest/pattern@30.0.1':
-    dependencies:
-      '@types/node': 24.6.2
-      jest-regex-util: 30.0.1
-
-  '@jest/schemas@30.0.5':
-    dependencies:
-      '@sinclair/typebox': 0.34.41
-
-  '@jest/snapshot-utils@30.2.0':
-    dependencies:
-      '@jest/types': 30.2.0
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      natural-compare: 1.4.0
-
-  '@jest/transform@30.2.0':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@jest/types': 30.2.0
-      '@jridgewell/trace-mapping': 0.3.31
-      babel-plugin-istanbul: 7.0.1
-      chalk: 4.1.2
-      convert-source-map: 2.0.0
-      fast-json-stable-stringify: 2.1.0
-      graceful-fs: 4.2.11
-      jest-haste-map: 30.2.0
-      jest-regex-util: 30.0.1
-      jest-util: 30.2.0
-      micromatch: 4.0.8
-      pirates: 4.0.7
-      slash: 3.0.0
-      write-file-atomic: 5.0.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@jest/types@30.2.0':
-    dependencies:
-      '@jest/pattern': 30.0.1
-      '@jest/schemas': 30.0.5
-      '@types/istanbul-lib-coverage': 2.0.6
-      '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.6.2
-      '@types/yargs': 17.0.33
-      chalk: 4.1.2
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2728,7 +2341,10 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@pkgr/core@0.2.9': {}
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@polka/url@1.0.0-next.29': {}
 
   '@rolldown/pluginutils@1.0.0-beta.38': {}
 
@@ -2798,16 +2414,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.52.3':
     optional: true
 
-  '@sinclair/typebox@0.34.41': {}
-
-  '@sinonjs/commons@3.0.1':
-    dependencies:
-      type-detect: 4.0.8
-
-  '@sinonjs/fake-timers@13.0.5':
-    dependencies:
-      '@sinonjs/commons': 3.0.1
-
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -2867,21 +2473,12 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/istanbul-lib-coverage@2.0.6': {}
-
-  '@types/istanbul-lib-report@3.0.3':
-    dependencies:
-      '@types/istanbul-lib-coverage': 2.0.6
-
-  '@types/istanbul-reports@3.0.4':
-    dependencies:
-      '@types/istanbul-lib-report': 3.0.3
-
   '@types/json-schema@7.0.15': {}
 
   '@types/node@24.6.2':
     dependencies:
       undici-types: 7.13.0
+    optional: true
 
   '@types/react-dom@19.1.9(@types/react@19.1.16)':
     dependencies:
@@ -2890,14 +2487,6 @@ snapshots:
   '@types/react@19.1.16':
     dependencies:
       csstype: 3.1.3
-
-  '@types/stack-utils@2.0.3': {}
-
-  '@types/yargs-parser@21.0.3': {}
-
-  '@types/yargs@17.0.33':
-    dependencies:
-      '@types/yargs-parser': 21.0.3
 
   '@typescript-eslint/eslint-plugin@8.45.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.8.3))(eslint@9.36.0)(typescript@5.8.3)':
     dependencies:
@@ -2992,8 +2581,6 @@ snapshots:
       '@typescript-eslint/types': 8.45.0
       eslint-visitor-keys: 4.2.1
 
-  '@ungap/structured-clone@1.3.0': {}
-
   '@vitejs/plugin-react@5.0.4(vite@7.1.7(@types/node@24.6.2))':
     dependencies:
       '@babel/core': 7.28.4
@@ -3003,6 +2590,24 @@ snapshots:
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
       vite: 7.1.7(@types/node@24.6.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9)':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.19
+      magicast: 0.3.5
+      std-env: 3.9.0
+      test-exclude: 7.0.1
+      tinyrainbow: 1.2.0
+      vitest: 2.1.9(@types/node@24.6.2)(@vitest/ui@4.0.10)(jsdom@25.0.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3025,6 +2630,10 @@ snapshots:
     dependencies:
       tinyrainbow: 1.2.0
 
+  '@vitest/pretty-format@4.0.10':
+    dependencies:
+      tinyrainbow: 3.0.3
+
   '@vitest/runner@2.1.9':
     dependencies:
       '@vitest/utils': 2.1.9
@@ -3040,11 +2649,27 @@ snapshots:
     dependencies:
       tinyspy: 3.0.2
 
+  '@vitest/ui@4.0.10(vitest@2.1.9)':
+    dependencies:
+      '@vitest/utils': 4.0.10
+      fflate: 0.8.2
+      flatted: 3.3.3
+      pathe: 2.0.3
+      sirv: 3.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vitest: 2.1.9(@types/node@24.6.2)(@vitest/ui@4.0.10)(jsdom@25.0.1)
+
   '@vitest/utils@2.1.9':
     dependencies:
       '@vitest/pretty-format': 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
+
+  '@vitest/utils@4.0.10':
+    dependencies:
+      '@vitest/pretty-format': 4.0.10
+      tinyrainbow: 3.0.3
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -3063,20 +2688,15 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
 
-  anymatch@3.1.3:
-    dependencies:
-      normalize-path: 3.0.0
-      picomatch: 2.3.1
-
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
+  ansi-styles@6.2.3: {}
 
   argparse@2.0.1: {}
 
@@ -3089,35 +2709,6 @@ snapshots:
   assertion-error@2.0.1: {}
 
   asynckit@0.4.0: {}
-
-  babel-plugin-istanbul@7.0.1:
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-      '@istanbuljs/load-nyc-config': 1.1.0
-      '@istanbuljs/schema': 0.1.3
-      istanbul-lib-instrument: 6.0.3
-      test-exclude: 6.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.4):
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.4)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.4)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.4)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.4)
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.4)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.4)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.4)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.4)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.4)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.4)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.4)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.4)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.4)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.4)
 
   balanced-match@1.0.2: {}
 
@@ -3144,10 +2735,6 @@ snapshots:
       node-releases: 2.0.21
       update-browserslist-db: 1.1.3(browserslist@4.26.2)
 
-  bser@2.1.1:
-    dependencies:
-      node-int64: 0.4.0
-
   cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -3156,8 +2743,6 @@ snapshots:
       function-bind: 1.1.2
 
   callsites@3.1.0: {}
-
-  camelcase@5.3.1: {}
 
   caniuse-lite@1.0.30001746: {}
 
@@ -3175,8 +2760,6 @@ snapshots:
       supports-color: 7.2.0
 
   check-error@2.1.1: {}
-
-  ci-info@4.3.0: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -3236,7 +2819,13 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
   electron-to-chromium@1.5.227: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   entities@6.0.1: {}
 
@@ -3314,8 +2903,6 @@ snapshots:
 
   escalade@3.2.0: {}
 
-  escape-string-regexp@2.0.0: {}
-
   escape-string-regexp@4.0.0: {}
 
   eslint-plugin-react-hooks@5.2.0(eslint@9.36.0):
@@ -3381,8 +2968,6 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 4.2.1
 
-  esprima@4.0.1: {}
-
   esquery@1.6.0:
     dependencies:
       estraverse: 5.3.0
@@ -3400,15 +2985,6 @@ snapshots:
   esutils@2.0.3: {}
 
   expect-type@1.2.2: {}
-
-  expect@30.2.0:
-    dependencies:
-      '@jest/expect-utils': 30.2.0
-      '@jest/get-type': 30.1.0
-      jest-matcher-utils: 30.2.0
-      jest-message-util: 30.2.0
-      jest-mock: 30.2.0
-      jest-util: 30.2.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -3428,13 +3004,11 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fb-watchman@2.0.2:
-    dependencies:
-      bser: 2.1.1
-
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -3443,11 +3017,6 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
-
-  find-up@4.1.0:
-    dependencies:
-      locate-path: 5.0.0
-      path-exists: 4.0.0
 
   find-up@5.0.0:
     dependencies:
@@ -3461,6 +3030,11 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
@@ -3468,8 +3042,6 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
-
-  fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -3491,8 +3063,6 @@ snapshots:
       hasown: 2.0.2
       math-intrinsics: 1.1.0
 
-  get-package-type@0.1.0: {}
-
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
@@ -3506,22 +3076,20 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob@7.2.3:
+  glob@10.4.5:
     dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   globals@14.0.0: {}
 
   globals@16.4.0: {}
 
   gopd@1.2.0: {}
-
-  graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
 
@@ -3540,6 +3108,8 @@ snapshots:
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
+
+  html-escaper@2.0.2: {}
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -3572,14 +3142,9 @@ snapshots:
 
   indent-string@4.0.0: {}
 
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
-
-  inherits@2.0.4: {}
-
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -3593,114 +3158,32 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
-  istanbul-lib-instrument@6.0.3:
+  istanbul-lib-report@3.0.1:
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/parser': 7.28.4
-      '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
 
-  jest-diff@30.2.0:
+  istanbul-reports@3.2.0:
     dependencies:
-      '@jest/diff-sequences': 30.0.1
-      '@jest/get-type': 30.1.0
-      chalk: 4.1.2
-      pretty-format: 30.2.0
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
 
-  jest-haste-map@30.2.0:
+  jackspeak@3.4.3:
     dependencies:
-      '@jest/types': 30.2.0
-      '@types/node': 24.6.2
-      anymatch: 3.1.3
-      fb-watchman: 2.0.2
-      graceful-fs: 4.2.11
-      jest-regex-util: 30.0.1
-      jest-util: 30.2.0
-      jest-worker: 30.2.0
-      micromatch: 4.0.8
-      walker: 1.0.8
+      '@isaacs/cliui': 8.0.2
     optionalDependencies:
-      fsevents: 2.3.3
-
-  jest-matcher-utils@30.2.0:
-    dependencies:
-      '@jest/get-type': 30.1.0
-      chalk: 4.1.2
-      jest-diff: 30.2.0
-      pretty-format: 30.2.0
-
-  jest-message-util@30.2.0:
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@jest/types': 30.2.0
-      '@types/stack-utils': 2.0.3
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      micromatch: 4.0.8
-      pretty-format: 30.2.0
-      slash: 3.0.0
-      stack-utils: 2.0.6
-
-  jest-mock@30.2.0:
-    dependencies:
-      '@jest/types': 30.2.0
-      '@types/node': 24.6.2
-      jest-util: 30.2.0
-
-  jest-regex-util@30.0.1: {}
-
-  jest-snapshot@30.2.0:
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/generator': 7.28.3
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.4)
-      '@babel/types': 7.28.4
-      '@jest/expect-utils': 30.2.0
-      '@jest/get-type': 30.1.0
-      '@jest/snapshot-utils': 30.2.0
-      '@jest/transform': 30.2.0
-      '@jest/types': 30.2.0
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.4)
-      chalk: 4.1.2
-      expect: 30.2.0
-      graceful-fs: 4.2.11
-      jest-diff: 30.2.0
-      jest-matcher-utils: 30.2.0
-      jest-message-util: 30.2.0
-      jest-util: 30.2.0
-      pretty-format: 30.2.0
-      semver: 7.7.2
-      synckit: 0.11.11
-    transitivePeerDependencies:
-      - supports-color
-
-  jest-util@30.2.0:
-    dependencies:
-      '@jest/types': 30.2.0
-      '@types/node': 24.6.2
-      chalk: 4.1.2
-      ci-info: 4.3.0
-      graceful-fs: 4.2.11
-      picomatch: 4.0.3
-
-  jest-worker@30.2.0:
-    dependencies:
-      '@types/node': 24.6.2
-      '@ungap/structured-clone': 1.3.0
-      jest-util: 30.2.0
-      merge-stream: 2.0.0
-      supports-color: 8.1.1
+      '@pkgjs/parseargs': 0.11.0
 
   js-tokens@4.0.0: {}
-
-  js-yaml@3.14.1:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
 
   js-yaml@4.1.0:
     dependencies:
@@ -3753,10 +3236,6 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  locate-path@5.0.0:
-    dependencies:
-      p-locate: 4.1.0
-
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -3777,13 +3256,17 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  makeerror@1.0.12:
+  magicast@0.3.5:
     dependencies:
-      tmpl: 1.0.5
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.2
 
   math-intrinsics@1.1.0: {}
-
-  merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -3808,23 +3291,19 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
+  minipass@7.1.2: {}
+
+  mrmime@2.0.1: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
 
-  node-int64@0.4.0: {}
-
   node-releases@2.0.21: {}
 
-  normalize-path@3.0.0: {}
-
   nwsapi@2.2.22: {}
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
 
   optionator@0.9.4:
     dependencies:
@@ -3835,23 +3314,15 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  p-limit@2.3.0:
-    dependencies:
-      p-try: 2.2.0
-
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
-
-  p-locate@4.1.0:
-    dependencies:
-      p-limit: 2.3.0
 
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
 
-  p-try@2.2.0: {}
+  package-json-from-dist@1.0.1: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -3863,11 +3334,16 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-is-absolute@1.0.1: {}
-
   path-key@3.1.1: {}
 
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
+
   pathe@1.1.2: {}
+
+  pathe@2.0.3: {}
 
   pathval@2.0.1: {}
 
@@ -3876,8 +3352,6 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
-
-  pirates@4.0.7: {}
 
   postcss@8.5.6:
     dependencies:
@@ -3893,12 +3367,6 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
-  pretty-format@30.2.0:
-    dependencies:
-      '@jest/schemas': 30.0.5
-      ansi-styles: 5.2.0
-      react-is: 18.3.1
-
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
@@ -3910,8 +3378,6 @@ snapshots:
 
   react-is@17.0.2: {}
 
-  react-is@18.3.1: {}
-
   react-refresh@0.17.0: {}
 
   react@19.1.1: {}
@@ -3922,8 +3388,6 @@ snapshots:
       strip-indent: 3.0.0
 
   resolve-from@4.0.0: {}
-
-  resolve-from@5.0.0: {}
 
   reusify@1.1.0: {}
 
@@ -3985,19 +3449,37 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  slash@3.0.0: {}
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
 
   source-map-js@1.2.1: {}
-
-  sprintf-js@1.0.3: {}
-
-  stack-utils@2.0.6:
-    dependencies:
-      escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
 
   std-env@3.9.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.2
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.1.2:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-indent@3.0.0:
     dependencies:
@@ -4009,21 +3491,13 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  supports-color@8.1.1:
-    dependencies:
-      has-flag: 4.0.0
-
   symbol-tree@3.2.4: {}
 
-  synckit@0.11.11:
-    dependencies:
-      '@pkgr/core': 0.2.9
-
-  test-exclude@6.0.0:
+  test-exclude@7.0.1:
     dependencies:
       '@istanbuljs/schema': 0.1.3
-      glob: 7.2.3
-      minimatch: 3.1.2
+      glob: 10.4.5
+      minimatch: 9.0.5
 
   tinybench@2.9.0: {}
 
@@ -4038,6 +3512,8 @@ snapshots:
 
   tinyrainbow@1.2.0: {}
 
+  tinyrainbow@3.0.3: {}
+
   tinyspy@3.0.2: {}
 
   tldts-core@6.1.86: {}
@@ -4046,11 +3522,11 @@ snapshots:
     dependencies:
       tldts-core: 6.1.86
 
-  tmpl@1.0.5: {}
-
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  totalist@3.0.1: {}
 
   tough-cookie@5.1.2:
     dependencies:
@@ -4068,8 +3544,6 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  type-detect@4.0.8: {}
-
   typescript-eslint@8.45.0(eslint@9.36.0)(typescript@5.8.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.45.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.8.3))(eslint@9.36.0)(typescript@5.8.3)
@@ -4083,7 +3557,8 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  undici-types@7.13.0: {}
+  undici-types@7.13.0:
+    optional: true
 
   update-browserslist-db@1.1.3(browserslist@4.26.2):
     dependencies:
@@ -4134,7 +3609,7 @@ snapshots:
       '@types/node': 24.6.2
       fsevents: 2.3.3
 
-  vitest@2.1.9(@types/node@24.6.2)(jsdom@25.0.1):
+  vitest@2.1.9(@types/node@24.6.2)(@vitest/ui@4.0.10)(jsdom@25.0.1):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.20(@types/node@24.6.2))
@@ -4158,6 +3633,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.6.2
+      '@vitest/ui': 4.0.10(vitest@2.1.9)
       jsdom: 25.0.1
     transitivePeerDependencies:
       - less
@@ -4173,10 +3649,6 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
-
-  walker@1.0.8:
-    dependencies:
-      makeerror: 1.0.12
 
   webidl-conversions@7.0.0: {}
 
@@ -4202,12 +3674,17 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  wrappy@1.0.2: {}
-
-  write-file-atomic@5.0.1:
+  wrap-ansi@7.0.0:
     dependencies:
-      imurmurhash: 0.1.4
-      signal-exit: 4.1.0
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.1.2
 
   ws@8.18.3: {}
 

--- a/src/__tests__/collisionUtils.test.ts
+++ b/src/__tests__/collisionUtils.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../utils/collisionUtils';
 
 const block = (x: number, y: number, w: number, h: number) => ({
+  id: 1,
   position: { x, y },
   size: { width: w, height: h },
 });

--- a/src/__tests__/collisionUtils.test.ts
+++ b/src/__tests__/collisionUtils.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hasRectangleCollision,
+  hasCircleCollision,
+  hasCollision,
+} from '../utils/collisionUtils';
+
+const block = (x: number, y: number, w: number, h: number) => ({
+  position: { x, y },
+  size: { width: w, height: h },
+});
+
+describe('collisionUtils', () => {
+  describe('hasRectangleCollision', () => {
+    it('returns false when rectangles do not overlap', () => {
+      const a = block(0, 0, 50, 50);
+      const b = block(60, 0, 50, 50);
+      expect(hasRectangleCollision(a, b)).toBe(false);
+    });
+
+    it('returns true when rectangles overlap', () => {
+      const a = block(0, 0, 50, 50);
+      const b = block(25, 25, 50, 50);
+      expect(hasRectangleCollision(a, b)).toBe(true);
+    });
+
+    it('returns false when rectangles are exactly touching edges', () => {
+      const a = block(0, 0, 50, 50);
+      const b = block(50, 0, 50, 50); // touch at edge
+      expect(hasRectangleCollision(a, b)).toBe(false);
+    });
+  });
+
+  describe('hasCircleCollision', () => {
+    it('returns false when circles are apart', () => {
+      const a = block(0, 0, 40, 40); // r=20 center (20,20)
+      const b = block(100, 0, 40, 40); // r=20 center (120,20)
+      expect(hasCircleCollision(a, b)).toBe(false);
+    });
+
+    it('returns true when circles overlap', () => {
+      const a = block(0, 0, 40, 40); // center (20,20)
+      const b = block(30, 0, 40, 40); // center (50,20) dist=30, rSum=40
+      expect(hasCircleCollision(a, b)).toBe(true);
+    });
+
+    it('returns false when circles just touch', () => {
+      const a = block(0, 0, 40, 40); // center (20,20)
+      const b = block(40, 0, 40, 40); // center (60,20) dist=40, rSum=40
+      expect(hasCircleCollision(a, b)).toBe(false);
+    });
+  });
+
+  describe('hasCollision (dispatcher)', () => {
+    it('dispatches to rectangle mode', () => {
+      const a = block(0, 0, 50, 50);
+      const b = block(25, 25, 50, 50);
+      expect(hasCollision(a, b, 'rectangle')).toBe(true);
+    });
+    it('dispatches to circle mode', () => {
+      const a = block(0, 0, 40, 40);
+      const b = block(30, 0, 40, 40);
+      expect(hasCollision(a, b, 'circle')).toBe(true);
+    });
+  });
+});

--- a/src/__tests__/isInBoundUtil.test.ts
+++ b/src/__tests__/isInBoundUtil.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import isInBound from '../utils/isInBoundUtil';
+
+const block = (w: number, h: number) => ({
+  size: { width: w, height: h },
+});
+
+describe('isInBoundUtil', () => {
+  const container = {
+    clientWidth: 300,
+    clientHeight: 200,
+  } as unknown as HTMLDivElement;
+  const defaultPos = { x: 0, y: 0 };
+  const defaultOffset = { x: 0, y: 10 };
+
+  it('returns true when fully inside container', () => {
+    const pos = { x: 10, y: 10 };
+    expect(
+      isInBound(pos, block(50, 50), 0, container, defaultPos, defaultOffset)
+    ).toBe(true);
+  });
+
+  it('returns false when left overflow', () => {
+    const pos = { x: -1, y: 10 };
+    expect(
+      isInBound(pos, block(50, 50), 0, container, defaultPos, defaultOffset)
+    ).toBe(false);
+  });
+
+  it('returns false when right overflow', () => {
+    const pos = { x: 260, y: 10 }; // 260 + 50 > 300
+    expect(
+      isInBound(pos, block(50, 50), 0, container, defaultPos, defaultOffset)
+    ).toBe(false);
+  });
+
+  it('returns false when bottom overflow', () => {
+    const pos = { x: 10, y: 160 }; // 160 + 50 > 200
+    expect(
+      isInBound(pos, block(50, 50), 0, container, defaultPos, defaultOffset)
+    ).toBe(false);
+  });
+});

--- a/src/__tests__/useCollisionDetection.test.tsx
+++ b/src/__tests__/useCollisionDetection.test.tsx
@@ -1,0 +1,59 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import { useCollisionDetection } from '../hooks/useCollisionDetection';
+import type { BlockType } from '../types';
+
+afterEach(() => {
+  cleanup();
+});
+
+type MyBlock = BlockType & { title: string };
+
+const TestComp: React.FC<{
+  blocks: MyBlock[];
+  mode?: 'rectangle' | 'circle';
+}> = ({ blocks, mode = 'rectangle' }) => {
+  const { collidedIds, computeCollisions } = useCollisionDetection<MyBlock>();
+  React.useEffect(() => {
+    computeCollisions(blocks, mode);
+  }, [blocks, mode, computeCollisions]);
+  return <div data-testid="ids">{JSON.stringify(collidedIds.sort())}</div>;
+};
+
+const block = (
+  id: number,
+  x: number,
+  y: number,
+  w: number,
+  h: number
+): MyBlock => ({
+  id,
+  position: { x, y },
+  size: { width: w, height: h },
+  title: String(id),
+});
+
+describe('useCollisionDetection', () => {
+  it('detects rectangle collisions', () => {
+    const blocks: MyBlock[] = [
+      block(1, 0, 0, 50, 50),
+      block(2, 25, 25, 50, 50),
+    ];
+    render(<TestComp blocks={blocks} mode="rectangle" />);
+    expect(screen.getByTestId('ids').textContent).toBe(JSON.stringify([1, 2]));
+  });
+
+  it('detects circle collisions', () => {
+    const blocks: MyBlock[] = [block(1, 0, 0, 40, 40), block(2, 30, 0, 40, 40)];
+    render(<TestComp blocks={blocks} mode="circle" />);
+    expect(screen.getByTestId('ids').textContent).toBe(JSON.stringify([1, 2]));
+  });
+
+  it('no collisions => empty list', () => {
+    const blocks: MyBlock[] = [block(1, 0, 0, 50, 50), block(2, 60, 0, 50, 50)];
+    render(<TestComp blocks={blocks} mode="rectangle" />);
+    expect(screen.getByTestId('ids').textContent).toBe(JSON.stringify([]));
+  });
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useDragBlock';
 export * from './useBlocksTransition';
 export * from './useSetPointerEvents';
+export * from './useRotateBlock';
 export * from './useCollisionDetection';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useDragBlock';
 export * from './useBlocksTransition';
 export * from './useSetPointerEvents';
+export * from './useCollisionDetection';

--- a/src/hooks/useCollisionDetection.ts
+++ b/src/hooks/useCollisionDetection.ts
@@ -1,9 +1,10 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import type { BlockType } from '../types';
 import { hasCollision, type CollisionType } from '../utils';
+import { setCollisionIds, useCollisionIds } from '../store/collisionStore';
 
 export const useCollisionDetection = <T extends BlockType>() => {
-  const [collidedIds, setCollidedIds] = useState<number[]>([]);
+  const collidedIds = useCollisionIds();
 
   const computeCollisions = useCallback(
     (blocks: T[], mode: CollisionType = 'rectangle') => {
@@ -17,11 +18,21 @@ export const useCollisionDetection = <T extends BlockType>() => {
         }
       }
       const result = Array.from(next);
-      setCollidedIds(result);
+      if (
+        collidedIds.length === result.length &&
+        collidedIds.every(id => result.includes(id))
+      ) {
+        return result;
+      }
+      setCollisionIds(result);
       return result;
     },
-    []
+    [collidedIds]
   );
 
-  return { collidedIds, computeCollisions, setCollidedIds };
+  return {
+    collidedIds,
+    computeCollisions,
+    setCollidedIds: setCollisionIds,
+  };
 };

--- a/src/hooks/useCollisionDetection.ts
+++ b/src/hooks/useCollisionDetection.ts
@@ -1,0 +1,31 @@
+import { useCallback, useState } from 'react';
+import type { BlockType } from '../types';
+import { hasRectangleCollision, hasCircleCollision } from '../utils';
+
+export type CollisionMode = 'rectangle' | 'circle';
+
+export const useCollisionDetection = <T extends BlockType>() => {
+  const [collidedIds, setCollidedIds] = useState<number[]>([]);
+
+  const computeCollisions = useCallback(
+    (blocks: T[], mode: CollisionMode = 'rectangle') => {
+      const next = new Set<number>();
+      const compare =
+        mode === 'rectangle' ? hasRectangleCollision : hasCircleCollision;
+      for (let i = 0; i < blocks.length; i++) {
+        for (let j = i + 1; j < blocks.length; j++) {
+          if (compare(blocks[i], blocks[j])) {
+            next.add(Number(blocks[i].id));
+            next.add(Number(blocks[j].id));
+          }
+        }
+      }
+      const result = Array.from(next);
+      setCollidedIds(result);
+      return result;
+    },
+    []
+  );
+
+  return { collidedIds, computeCollisions, setCollidedIds };
+};

--- a/src/hooks/useCollisionDetection.ts
+++ b/src/hooks/useCollisionDetection.ts
@@ -1,20 +1,16 @@
 import { useCallback, useState } from 'react';
 import type { BlockType } from '../types';
-import { hasRectangleCollision, hasCircleCollision } from '../utils';
-
-export type CollisionMode = 'rectangle' | 'circle';
+import { hasCollision, type CollisionType } from '../utils';
 
 export const useCollisionDetection = <T extends BlockType>() => {
   const [collidedIds, setCollidedIds] = useState<number[]>([]);
 
   const computeCollisions = useCallback(
-    (blocks: T[], mode: CollisionMode = 'rectangle') => {
+    (blocks: T[], mode: CollisionType = 'rectangle') => {
       const next = new Set<number>();
-      const compare =
-        mode === 'rectangle' ? hasRectangleCollision : hasCircleCollision;
       for (let i = 0; i < blocks.length; i++) {
         for (let j = i + 1; j < blocks.length; j++) {
-          if (compare(blocks[i], blocks[j])) {
+          if (hasCollision(blocks[i], blocks[j], mode)) {
             next.add(Number(blocks[i].id));
             next.add(Number(blocks[j].id));
           }

--- a/src/hooks/useDragBlock.ts
+++ b/src/hooks/useDragBlock.ts
@@ -41,8 +41,7 @@ export const useDragBlock = <T extends BlockType>({
 
   //마우스 위치와 블록 위치 차이
   const [dragOffset, setDragOffset] = useState<Position>({ x: 0, y: 0 });
-  const { collidedIds, computeCollisions, setCollidedIds } =
-    useCollisionDetection<T>();
+  const { computeCollisions, setCollidedIds } = useCollisionDetection<T>();
 
   const enableCollision = collisionOptions?.enabled ?? false;
   const collisionType: CollisionType = collisionOptions?.mode ?? 'rectangle';
@@ -168,9 +167,9 @@ export const useDragBlock = <T extends BlockType>({
     updateWorkBlockCallback,
     workBlocks,
     computeCollisions,
-    setCollidedIds,
     enableCollision,
     collisionType,
+    setCollidedIds,
   ]);
 
   useSetPointerEvents({
@@ -183,6 +182,5 @@ export const useDragBlock = <T extends BlockType>({
     dragPointerPosition,
     dragOffset,
     handleStartDrag,
-    collidedIds,
   };
 };

--- a/src/hooks/useDragBlock.ts
+++ b/src/hooks/useDragBlock.ts
@@ -5,10 +5,9 @@ import { useBlocksTransition } from './useBlocksTransition';
 import { useSetPointerEvents } from './useSetPointerEvents';
 import { snapPositionToGrid } from '../utils/snapToGridUtil';
 import type { BlockType } from '../types';
-import { resolveCollision } from '../utils';
+import { resolveCollision, type CollisionType } from '../utils';
 import { getNewBlocks } from '../utils/blockUtils.ts';
 import { useCollisionDetection } from './useCollisionDetection';
-import type { CollisionMode } from './useCollisionDetection';
 
 interface UseDragBlockProps<T extends BlockType> {
   containerRef: RefObject<HTMLDivElement | null>;
@@ -18,7 +17,7 @@ interface UseDragBlockProps<T extends BlockType> {
   updateWorkBlocks: (blocks: T[]) => void;
   collisionOptions?: {
     enabled?: boolean;
-    mode?: CollisionMode;
+    mode?: CollisionType;
   };
   snapToGridOptions?: {
     enabled?: boolean;
@@ -46,7 +45,7 @@ export const useDragBlock = <T extends BlockType>({
     useCollisionDetection<T>();
 
   const enableCollision = collisionOptions?.enabled ?? false;
-  const collisionMode: CollisionMode = collisionOptions?.mode ?? 'rectangle';
+  const collisionType: CollisionType = collisionOptions?.mode ?? 'rectangle';
 
   const enableSnapToGrid = snapToGridOptions?.enabled ?? false;
   const gridSize = snapToGridOptions?.gridSize ?? 0;
@@ -150,6 +149,7 @@ export const useDragBlock = <T extends BlockType>({
       workBlocks,
       containerRef,
       scrollOffset,
+      collisionType,
     });
 
     animateBlocksTransition(newBlocks, sortedBlocks);
@@ -158,7 +158,7 @@ export const useDragBlock = <T extends BlockType>({
 
     if (enableCollision) {
       // enableCollision 옵션이 활성화되어 있으면 충돌 처리
-      computeCollisions(newBlocks, collisionMode);
+      computeCollisions(newBlocks, collisionType);
     }
   }, [
     animateBlocksTransition,
@@ -170,7 +170,7 @@ export const useDragBlock = <T extends BlockType>({
     computeCollisions,
     setCollidedIds,
     enableCollision,
-    collisionMode,
+    collisionType,
   ]);
 
   useSetPointerEvents({

--- a/src/hooks/useDragBlock.ts
+++ b/src/hooks/useDragBlock.ts
@@ -7,21 +7,33 @@ import { snapPositionToGrid } from '../utils/snapToGridUtil';
 import type { BlockType } from '../types';
 import { resolveCollision } from '../utils';
 import { getNewBlocks } from '../utils/blockUtils.ts';
+import { useCollisionDetection } from './useCollisionDetection';
+import type { CollisionMode } from './useCollisionDetection';
 
 interface UseDragBlockProps<T extends BlockType> {
   containerRef: RefObject<HTMLDivElement | null>;
   scrollOffset: number;
   workBlocks: T[];
-  updateWorkBlockTimeOnServer: (updatedBlock: T) => void;
+  updateWorkBlockCallback: (updatedBlock: T) => void;
   updateWorkBlocks: (blocks: T[]) => void;
+  collisionOptions?: {
+    enabled?: boolean;
+    mode?: CollisionMode;
+  };
+  snapToGridOptions?: {
+    enabled?: boolean;
+    gridSize?: number;
+  };
 }
 
 export const useDragBlock = <T extends BlockType>({
   containerRef,
   scrollOffset,
   workBlocks,
-  updateWorkBlockTimeOnServer,
+  updateWorkBlockCallback,
   updateWorkBlocks,
+  collisionOptions = { enabled: false, mode: 'rectangle' },
+  snapToGridOptions = { enabled: false, gridSize: 0 },
 }: UseDragBlockProps<T>) => {
   const [draggingBlock, setDraggingBlock] = useState<T | null>(null);
   //렌더링 시에만 사용하는 위치, scrollOffset 보정 x
@@ -30,6 +42,14 @@ export const useDragBlock = <T extends BlockType>({
 
   //마우스 위치와 블록 위치 차이
   const [dragOffset, setDragOffset] = useState<Position>({ x: 0, y: 0 });
+  const { collidedIds, computeCollisions, setCollidedIds } =
+    useCollisionDetection<T>();
+
+  const enableCollision = collisionOptions?.enabled ?? false;
+  const collisionMode: CollisionMode = collisionOptions?.mode ?? 'rectangle';
+
+  const enableSnapToGrid = snapToGridOptions?.enabled ?? false;
+  const gridSize = snapToGridOptions?.gridSize ?? 0;
 
   // 블록 이동 애니메이션 훅
   const { animateBlocksTransition } = useBlocksTransition<T>(updateWorkBlocks);
@@ -71,18 +91,30 @@ export const useDragBlock = <T extends BlockType>({
         y: containerCoords.y - dragOffset.y,
       };
 
-      // 6px 그리드에 스냅 (y는 validY로 제한)
-      const snappedPosition = snapPositionToGrid({
-        x: newPosition.x,
-        y: newPosition.y,
-      });
+      // 그리드 스냅 처리
+      const snappedPosition = enableSnapToGrid
+        ? snapPositionToGrid(
+            {
+              x: newPosition.x,
+              y: newPosition.y,
+            },
+            gridSize ?? 0
+          )
+        : newPosition;
 
       setDraggingBlock({
         ...draggingBlock,
         position: snappedPosition,
       });
     },
-    [draggingBlock, dragOffset, getContainerCoords, scrollOffset]
+    [
+      draggingBlock,
+      dragOffset,
+      getContainerCoords,
+      scrollOffset,
+      enableSnapToGrid,
+      gridSize,
+    ]
   );
 
   const handleEndDrag = useCallback(() => {
@@ -108,6 +140,7 @@ export const useDragBlock = <T extends BlockType>({
         getNewBlocks(workBlocks, currentDraggingBlock),
         workBlocks
       );
+      setCollidedIds([]);
       return;
     }
 
@@ -120,15 +153,24 @@ export const useDragBlock = <T extends BlockType>({
     });
 
     animateBlocksTransition(newBlocks, sortedBlocks);
+    updateWorkBlockCallback(updatedBlock);
+    // 드랍 후 충돌 블록 id 계산
 
-    updateWorkBlockTimeOnServer(updatedBlock);
+    if (enableCollision) {
+      // enableCollision 옵션이 활성화되어 있으면 충돌 처리
+      computeCollisions(newBlocks, collisionMode);
+    }
   }, [
     animateBlocksTransition,
     containerRef,
     draggingBlock,
     scrollOffset,
-    updateWorkBlockTimeOnServer,
+    updateWorkBlockCallback,
     workBlocks,
+    computeCollisions,
+    setCollidedIds,
+    enableCollision,
+    collisionMode,
   ]);
 
   useSetPointerEvents({
@@ -141,5 +183,6 @@ export const useDragBlock = <T extends BlockType>({
     dragPointerPosition,
     dragOffset,
     handleStartDrag,
+    collidedIds,
   };
 };

--- a/src/hooks/useRotateBlock.ts
+++ b/src/hooks/useRotateBlock.ts
@@ -1,0 +1,120 @@
+import { useCallback, useState, type RefObject } from 'react';
+import type { BlockType } from '../types';
+import { useSetPointerEvents } from './useSetPointerEvents';
+import { resolveCollision, type CollisionType } from '../utils';
+import { useCollisionDetection } from './useCollisionDetection';
+import { useBlocksTransition } from './useBlocksTransition';
+
+interface UseRotateBlockProps<T extends BlockType> {
+  containerRef: RefObject<HTMLDivElement | null>;
+  scrollOffset: number;
+  workBlocks: T[];
+  updateWorkBlockCallback: (updatedBlock: T) => void;
+  updateWorkBlocks: (blocks: T[]) => void;
+  collisionOptions?: {
+    enabled?: boolean;
+    mode?: CollisionType;
+  };
+}
+
+export const useRotateBlock = <T extends BlockType>({
+  containerRef,
+  scrollOffset,
+  workBlocks,
+  updateWorkBlockCallback,
+  updateWorkBlocks,
+  collisionOptions = { enabled: false, mode: 'obb' },
+}: UseRotateBlockProps<T>) => {
+  const { computeCollisions, collidedIds } = useCollisionDetection<T>();
+
+  const enableCollision = collisionOptions?.enabled ?? false;
+  const collisionType: CollisionType = collisionOptions?.mode ?? 'obb';
+
+  const { animateBlocksTransition } = useBlocksTransition<T>(updateWorkBlocks);
+
+  const [rotatingBlock, setRotatingBlock] = useState<T | null>(null);
+  const [startPointerAngleRad, setStartPointerAngleRad] = useState<
+    number | null
+  >(null);
+  const [startAngleDeg, setStartAngleDeg] = useState<number>(0);
+
+  const handleStartRotate = useCallback(
+    (e: PointerEvent, block: T) => {
+      const rect = containerRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const centerX = rect.left + block.position.x + block.size.width / 2;
+      const centerY = rect.top + block.position.y + block.size.height / 2;
+      const pointerAngle = Math.atan2(e.clientY - centerY, e.clientX - centerX);
+      setStartPointerAngleRad(pointerAngle);
+      setStartAngleDeg(block.angle ?? 0);
+      setRotatingBlock(block);
+    },
+    [containerRef]
+  );
+
+  const handlePointerMove = useCallback(
+    (e: PointerEvent) => {
+      if (!rotatingBlock || startPointerAngleRad === null) return;
+      const rect = containerRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const centerX =
+        rect.left + rotatingBlock.position.x + rotatingBlock.size.width / 2;
+      const centerY =
+        rect.top + rotatingBlock.position.y + rotatingBlock.size.height / 2;
+      const currentAngleRad = Math.atan2(
+        e.clientY - centerY,
+        e.clientX - centerX
+      );
+      const deltaRad = currentAngleRad - startPointerAngleRad;
+      const deltaDeg = (deltaRad * 180) / Math.PI;
+      const nextDeg = startAngleDeg + deltaDeg;
+
+      setRotatingBlock({ ...rotatingBlock, angle: nextDeg });
+    },
+    [containerRef, rotatingBlock, startPointerAngleRad, startAngleDeg]
+  );
+
+  const handlePointerUp = useCallback(() => {
+    if (!rotatingBlock) return;
+    setRotatingBlock(null);
+    setStartPointerAngleRad(null);
+
+    // 충돌 해결 및 블록 정렬
+    const { newBlocks, sortedBlocks, updatedBlock } = resolveCollision({
+      activeBlock: rotatingBlock,
+      workBlocks,
+      containerRef,
+      scrollOffset,
+      collisionType,
+    });
+
+    animateBlocksTransition(newBlocks, sortedBlocks);
+    updateWorkBlockCallback(updatedBlock);
+
+    if (enableCollision) {
+      // enableCollision 옵션이 활성화되어 있으면 충돌 처리
+      computeCollisions(sortedBlocks, collisionType);
+    }
+  }, [
+    rotatingBlock,
+    workBlocks,
+    containerRef,
+    scrollOffset,
+    collisionType,
+    animateBlocksTransition,
+    updateWorkBlockCallback,
+    enableCollision,
+    computeCollisions,
+  ]);
+
+  useSetPointerEvents({
+    onPointerMove: handlePointerMove,
+    onPointerUp: handlePointerUp,
+  });
+
+  return {
+    rotatingBlock,
+    handleStartRotate,
+    collidedIds,
+  };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export {
   useDragBlock,
   useBlocksTransition,
   useSetPointerEvents,
+  useRotateBlock,
 } from './hooks';
 export * from './types';
 export * from './utils';

--- a/src/store/collisionStore.ts
+++ b/src/store/collisionStore.ts
@@ -1,0 +1,25 @@
+import { useSyncExternalStore } from 'react';
+
+let ids: number[] = [];
+const listeners = new Set<() => void>();
+
+const emit = () => {
+  for (const l of listeners) l();
+};
+
+export const getCollisionIds = (): number[] => ids;
+
+export const setCollisionIds = (next: number[]) => {
+  ids = next;
+  emit();
+};
+
+export const subscribeCollisionIds = (listener: () => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const useCollisionIds = () =>
+  useSyncExternalStore(subscribeCollisionIds, getCollisionIds, getCollisionIds);

--- a/src/types/blockType.type.ts
+++ b/src/types/blockType.type.ts
@@ -5,4 +5,5 @@ export interface BlockType {
   id: number;
   position: Position;
   size: Size;
+  angle?: number;
 }

--- a/src/utils/collisionUtils.ts
+++ b/src/utils/collisionUtils.ts
@@ -204,7 +204,6 @@ export const resolveCollision = <T extends BlockType>({
       collisionType
     )
   ) {
-    // 현재 블록이 가득차있는 블록이면 y좌표를 증가하여 생성
     const newPosition = {
       x: activeBlock.position.x,
       y: activeBlock.position.y, // TODO: 충돌 처리 후 이동 가능한 위치 반환

--- a/src/utils/collisionUtils.ts
+++ b/src/utils/collisionUtils.ts
@@ -5,6 +5,16 @@ import type { RefObject } from 'react';
 import { getNewBlocks } from './blockUtils.ts';
 
 // 충돌 감지 함수
+export const hasCollision = (
+  currentBlock: { position: Position; size: Size },
+  targetBlock: { position: Position; size: Size },
+  collisionType: 'rectangle' | 'circle' = 'rectangle'
+): boolean => {
+  return collisionType === 'rectangle'
+    ? hasRectangleCollision(currentBlock, targetBlock)
+    : hasCircleCollision(currentBlock, targetBlock);
+};
+
 export const hasRectangleCollision = (
   currentBlock: { position: Position; size: Size },
   targetBlock: { position: Position; size: Size }
@@ -50,11 +60,12 @@ export const hasCircleCollision = (
 export const hasCollisionWithOthers = <T extends BlockType>(
   draggingBlock: T,
   workBlocks: T[],
-  draggingBlockId: number
+  draggingBlockId: number,
+  collisionType: 'rectangle' | 'circle' = 'rectangle'
 ): boolean => {
   return workBlocks.some(block => {
     if (block.id === draggingBlockId) return false;
-    return hasRectangleCollision(draggingBlock, block);
+    return hasCollision(draggingBlock, block, collisionType);
   });
 };
 


### PR DESCRIPTION
## 📌 연관된 이슈

- close #1

---

## 📝작업 내용

사각형 기준으로만 충돌 처리가 가능했던 기존 로직에서, 원 기준과 OBB(rotate된 사각형) 기준으로 충돌 처리가 가능하도록 collisionType을 추가했습니다.
또한 playground에서 직접 컴포넌트를 rotate 하며 테스트하기 위해 useRotateBlock 훅을 추가했는데,
useDragBlock에서 확인할 수 있는 충돌 여부와 useRotateBlock에서 확인할 수 있는 충돌 여부를 동기화하기 위해 충돌된 컴포넌트 상태를 전역으로 관리할 수 있는 collisionStore을 추가했습니다.
=> 그러나 충돌된 컴포넌트 상태를 전역으로 관리하는 collisionStore에는 한가지 문제가 있습니다. 여러 컴포넌트에서 각기 다른 데이터를 다룰 때, 컴포넌트의 id 가 같다면 다른 컴포넌트에서 충돌 처리가 되더라도 모두 똑같이 충돌한 것 처럼 인식이 됩니다. 이 문제를 해결하기 위해 ContextProvider을 이용해 충돌 상태를 지역적으로 관리하려고 했으나, 코드가 너무 복잡하고 보일러플레이트가 많아져 쉽고 간단한 API라는 ddo-dnd의 설계원칙에 어긋나기에 전역 상태로 관리하려고 합니다. 각 데이터의 id를 다르게 설정하면 충돌 상태가 공유되는 문제를 해결할 수 있습니다.


OBB 알고리즘 구현 참고 자료

[https://m.blog.naver.com/skz1024/222758566138](https://m.blog.naver.com/skz1024/222758566138)
[https://justicehui.github.io/other-algorithm/2018/06/23/OBB/](https://justicehui.github.io/other-algorithm/2018/06/23/OBB/)

---

### 스크린샷 (선택)

원형 충돌, 사각형 충돌, OBB 충돌 예시

https://github.com/user-attachments/assets/c8679827-f2cb-49ae-a5a4-c7aa7a3cf80f


---
