### PR TITLE
fix/#13: ci error 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,6 @@ on:
     branches:
       - 'main'
       - 'develop'
-  push:
-    branches:
-      - 'main'
-      - 'develop'
   merge_group:
     branches:
       - 'main'


### PR DESCRIPTION
## 📌 연관된 이슈

- close #13

---

## 📝작업 내용

push 시, pr open 시 ci가 실행되게 해뒀는데, push를 하면 `ref: refs/pull/${{ github.event.pull_request.number }}/merge` 에서 pr reference를 가져올 수 없어 에러가 발생했다.
생각해보니 push 할 때는 ci가 굳이 돌아갈 필요가 없는거같아서 Push 시 ci가 실행되지 않게 수정했다.

---

### 스크린샷 (선택)

---
